### PR TITLE
[RHCLOUD-29510] Add end conversation banner

### DIFF
--- a/src/Components/AstroChat/useAstro.ts
+++ b/src/Components/AstroChat/useAstro.ts
@@ -2,8 +2,7 @@ import { Dispatch, SetStateAction, useCallback, useState } from 'react';
 import { original, produce } from 'immer';
 
 import useChrome from '@redhat-cloud-services/frontend-components/useChrome';
-
-import { AssistantMessage, FeedbackMessage, From, Message } from '../../types/Message';
+import { AssistantMessage, Banner, FeedbackMessage, From, Message, SystemMessage } from '../../types/Message';
 import { PostTalkResponse, postTalk } from '../../api/PostTalk';
 import { asyncSleep } from '../../utils/Async';
 import Config from '../../Config';
@@ -127,6 +126,34 @@ export const useAstro = (messageProcessors: Array<MessageProcessor>) => {
 
   const { toggleFeedbackModal } = useChrome();
 
+  const addSystemMessage = (systemMessageType: string, additionalContent: Array<string>): void => {
+    const systemMessage: SystemMessage = {
+      from: From.SYSTEM,
+      content: 'system_message',
+      type: systemMessageType,
+      additionalContent: additionalContent,
+    };
+    setMessages(
+      produce((draft) => {
+        draft.push(systemMessage);
+      })
+    );
+  };
+
+  const addBanner = (bannerType: string, additionalContent: Array<string>): void => {
+    const banner: Banner = {
+      from: From.INTERFACE,
+      content: 'banner',
+      type: bannerType,
+      additionalContent: additionalContent,
+    };
+    setMessages(
+      produce((draft) => {
+        draft.push(banner);
+      })
+    );
+  };
+
   const ask = useCallback(
     async (message: string, options?: Partial<AskOptions>) => {
       if (loadingResponse) {
@@ -165,6 +192,8 @@ export const useAstro = (messageProcessors: Array<MessageProcessor>) => {
 
           const messageProcessorOptions = {
             toggleFeedbackModal,
+            addSystemMessage,
+            addBanner,
           };
 
           await loadMessage(
@@ -231,6 +260,7 @@ export const useAstro = (messageProcessors: Array<MessageProcessor>) => {
   return {
     ask,
     messages,
+    setMessages,
     start,
     stop,
     status,

--- a/src/Components/Banners/ConversationEndBanner.tsx
+++ b/src/Components/Banners/ConversationEndBanner.tsx
@@ -1,0 +1,14 @@
+import React, { FunctionComponent } from 'react';
+import { Alert, TextContent } from '@patternfly/react-core';
+import { MessageProps } from '../Message/MessageProps';
+import { Banner } from '../../types/Message';
+
+export const ConversationEndBanner: FunctionComponent<MessageProps<Banner>> = ({ message }) => {
+  return (
+    <>
+      <TextContent className="banner__chat-end">
+        <Alert variant="info" isInline title="You can start a new conversation at anytime by typing below." component="h6" className="banner-alert" />
+      </TextContent>
+    </>
+  );
+};

--- a/src/Components/Message/BannerEntry.tsx
+++ b/src/Components/Message/BannerEntry.tsx
@@ -1,0 +1,8 @@
+import React, { FunctionComponent } from 'react';
+import { MessageProps } from './MessageProps';
+import { Banner } from '../../types/Message';
+import { ConversationEndBanner } from '../Banners/ConversationEndBanner';
+
+export const BannerEntry: FunctionComponent<MessageProps<Banner>> = ({ message }) => {
+  return <>{message.type === 'finish_conversation_banner' && <ConversationEndBanner message={message} />}</>;
+};

--- a/src/Components/Message/MessageProcessor.ts
+++ b/src/Components/Message/MessageProcessor.ts
@@ -4,4 +4,6 @@ export type MessageProcessor = (message: AssistantMessage | FeedbackMessage, opt
 
 export type MessageProcessorOptions = {
   toggleFeedbackModal: (isOpen: boolean) => void;
+  addSystemMessage: (systemMessageType: string, additionalContent: Array<string>) => void;
+  addBanner: (bannerType: string, additionalContent: Array<string>) => void;
 };

--- a/src/Components/Message/SystemMessageEntry.tsx
+++ b/src/Components/Message/SystemMessageEntry.tsx
@@ -1,0 +1,22 @@
+import React, { FunctionComponent } from 'react';
+import { Text, TextContent, TextVariants } from '@patternfly/react-core';
+import { MessageProps } from './MessageProps';
+import { SystemMessage } from '../../types/Message';
+
+export const SystemMessageEntry: FunctionComponent<MessageProps<SystemMessage>> = ({ message }) => {
+  let systemMessageText = '';
+
+  switch (message.type) {
+    case 'finish_conversation_message':
+      systemMessageText = 'End of conversation';
+  }
+  return (
+    <>
+      <TextContent className="system-message">
+        <Text component={TextVariants.small} className="system-message-text">
+          {systemMessageText}
+        </Text>
+      </TextContent>
+    </>
+  );
+};

--- a/src/SharedComponents/AstroVirtualAssistant/AstroVirtualAssistant.tsx
+++ b/src/SharedComponents/AstroVirtualAssistant/AstroVirtualAssistant.tsx
@@ -13,7 +13,7 @@ import { commandMessageProcessor } from './CommandMessageProcessor';
 const messageProcessors = [commandMessageProcessor];
 
 export const AstroVirtualAssistant: FunctionComponent = () => {
-  const { messages, ask, start, status, loadingResponse } = useAstro(messageProcessors);
+  const { messages, setMessages, ask, start, status, loadingResponse } = useAstro(messageProcessors);
   const [isOpen, setOpen] = useState<boolean>(false);
   const chrome = useChrome();
 
@@ -30,6 +30,7 @@ export const AstroVirtualAssistant: FunctionComponent = () => {
           <AstroChat
             key="astro-chat"
             messages={messages}
+            setMessages={setMessages}
             ask={ask}
             blockInput={loadingResponse}
             preview={chrome.isBeta()}

--- a/src/SharedComponents/AstroVirtualAssistant/CommandMessageProcessor.tsx
+++ b/src/SharedComponents/AstroVirtualAssistant/CommandMessageProcessor.tsx
@@ -13,15 +13,12 @@ const startPendoTour = (tourId: string) => {
   // TODO: Pendo tour
 };
 
-const finishConversation = (): void => {
-  // TODO: finish conversation; load banner
-};
-
 export const commandMessageProcessor: MessageProcessor = async (message, options) => {
   if (message.from === From.ASSISTANT && message.command) {
     switch (message.command.type) {
       case CommandType.FINISH_CONVERSATION:
-        finishConversation();
+        options.addSystemMessage('finish_conversation_message', []);
+        options.addBanner('finish_conversation_banner', []);
         break;
       case CommandType.REDIRECT:
         if (message.command.params.url) {

--- a/src/SharedComponents/AstroVirtualAssistant/astro-virtual-assistant.scss
+++ b/src/SharedComponents/AstroVirtualAssistant/astro-virtual-assistant.scss
@@ -58,6 +58,24 @@
     .pf-c-label {
       --pf-c-label__content--before--BorderColor: var(--pf-v5-c-label--m-red__icon--Color);
     }
+    .system-message {
+      .system-message-text {
+        padding-bottom: var(--pf-global--spacer--md);
+        text-align: center;
+      }
+    }
+    .banner {
+      &__chat-end {
+        padding-top: 0;
+        padding-bottom: var(--pf-global--spacer--md);
+        .banner-alert {
+          .pf-c-alert__title {
+            margin-top: 0;
+            font-size: var(--pf-global--FontSize--sm);
+          }
+        }
+      }
+    }
   }
   &__footer {
     .pf-c-input-group {

--- a/src/types/Message.ts
+++ b/src/types/Message.ts
@@ -4,6 +4,8 @@ export enum From {
   ASSISTANT = 'assistant',
   USER = 'user',
   FEEDBACK = 'feedback',
+  SYSTEM = 'system',
+  INTERFACE = 'interface',
 }
 
 // Base
@@ -38,4 +40,18 @@ export interface FeedbackMessage extends BaseMessage {
   isLoading: boolean;
 }
 
-export type Message = AssistantMessage | UserMessage | FeedbackMessage;
+// System messages
+export interface SystemMessage extends BaseMessage {
+  from: From.SYSTEM;
+  type: string;
+  additionalContent?: Array<string>;
+}
+
+// Banners
+export interface Banner extends BaseMessage {
+  from: From.INTERFACE;
+  type: string;
+  additionalContent?: Array<string>;
+}
+
+export type Message = AssistantMessage | UserMessage | FeedbackMessage | SystemMessage | Banner;


### PR DESCRIPTION
This PR does the following:

- introduces a new type of messages called System messages
- adds support for banners under the system message type
- Adds a conversation end banner which triggers when the finish conversation command is received from the server

Conversation End:
![image](https://github.com/RedHatInsights/astro-virtual-assistant-frontend/assets/17099954/93c20e67-f7b2-4016-bfa4-d5bc96df310d)

New Conversation:
![image](https://github.com/RedHatInsights/astro-virtual-assistant-frontend/assets/17099954/7fbcb933-bc50-403e-9b9e-bd7398947b54)

