### PR TITLE
Tweak badge styling

### DIFF
--- a/src/Components/AstroAvatar/AstroBadge.scss
+++ b/src/Components/AstroAvatar/AstroBadge.scss
@@ -1,13 +1,13 @@
 .astro-c-button-badge {
-  background: var(--pf-v5-global--palette--red-200);
-  border-radius: 5px;
-  height: 50px;
-  padding: 6px;
-  width: 50px;
+  background: linear-gradient(180deg, #C9190B 0%, #A30000 100%, #3D0000 100.01%);
+  border-radius: 30px;
+  height: 54px;
+  padding: 2px 0 0 0;
+  width: 54px;
   &:hover {
     background: var(--pf-v5-global--palette--red-300);
   }
   .astro__badge {
-    width: 100%;
+    width: 74%;
   }
 }


### PR DESCRIPTION
Old
<img width="454" alt="Screenshot 2024-07-25 at 9 31 44 AM" src="https://github.com/user-attachments/assets/f9c51725-4b73-44de-92a6-c61b0fc4dbd7">

New
<img width="460" alt="Screenshot 2024-07-25 at 9 31 22 AM" src="https://github.com/user-attachments/assets/9738e48e-6435-4a89-b39f-511ed7613f27">
