### PR TITLE
RHCLOUD-39080 Wraps text in code/pre tags

### DIFF
--- a/src/v2/SharedComponents/AstroVirtualAssistant/astro-virtual-assistant.scss
+++ b/src/v2/SharedComponents/AstroVirtualAssistant/astro-virtual-assistant.scss
@@ -82,4 +82,12 @@
   .astro-option-disabled {
     pointer-events: none;
   }
+
+  code {
+    text-wrap: wrap;
+  }
+
+  pre {
+    text-wrap: wrap;
+  }
 }


### PR DESCRIPTION
[RHCLOUD-39080](https://issues.redhat.com/browse/RHCLOUD-39080)

Text was set to not wrap inside those tags.

Before:
![image](https://github.com/user-attachments/assets/8646ee70-878e-437a-ad83-0a53728cb83e)


After:
![image](https://github.com/user-attachments/assets/0b8b3e8c-5183-46ec-ad69-d5a66c479b11)
