### PR TITLE
fix: use portal auth check for ARH chat

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -4,6 +4,7 @@ module.exports = {
   coverageDirectory: './coverage/',
   moduleNameMapper: {
     '\\.(css|scss)$': 'identity-obj-proxy',
+    '\\.(svg|png|jpg|jpeg|gif)$': '<rootDir>/src/__mocks__/fileMock.js',
   },
   roots: ['<rootDir>/src/'],
   transformIgnorePatterns: ['/node_modules/(?!(@redhat-cloud-services|@patternfly)/)'],

--- a/src/Components/ARHClient/__tests__/checkARHAuth.test.ts
+++ b/src/Components/ARHClient/__tests__/checkARHAuth.test.ts
@@ -1,0 +1,113 @@
+/* eslint-disable @typescript-eslint/no-empty-function */
+import checkARHAuth from '../checkARHAuth';
+import { ChromeUser } from '@redhat-cloud-services/types';
+
+// Mock fetch
+global.fetch = jest.fn();
+
+const mockUser: ChromeUser = {
+  entitlements: {},
+  identity: {
+    account_number: '123456',
+    org_id: 'org-123',
+    internal: {
+      account_id: 'account-123',
+      org_id: 'org-123',
+    },
+    type: 'User',
+    user: {
+      username: 'testuser',
+      email: 'test@example.com',
+      first_name: 'Test',
+      last_name: 'User',
+      is_active: true,
+      is_internal: true,
+      is_org_admin: false,
+      locale: 'en-US',
+    },
+  },
+};
+
+describe('checkARHAuth', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should return true when user is entitled', async () => {
+    (fetch as jest.MockedFunction<typeof fetch>).mockResolvedValue({
+      ok: true,
+      json: async () => ({ isEntitled: true, isInternal: false }),
+    } as Response);
+
+    const result = await checkARHAuth('https://access.stage.redhat.com', mockUser, 'token');
+
+    expect(result).toBe(true);
+    expect(fetch).toHaveBeenCalledWith(
+      'https://access.stage.redhat.com/hydra/rest/contacts/sso/current?userId=account-123&assumeEntitledIfSubscriptionServiceUnavailable=true&redhat_client=cloud-services&account_number=123456',
+      {
+        method: 'GET',
+        headers: {
+          Authorization: 'Bearer token',
+          'Content-Type': 'application/json',
+        },
+      }
+    );
+  });
+
+  it('should return true when user is internal', async () => {
+    (fetch as jest.MockedFunction<typeof fetch>).mockResolvedValue({
+      ok: true,
+      json: async () => ({ isEntitled: false, isInternal: true }),
+    } as Response);
+
+    const result = await checkARHAuth('https://access.stage.redhat.com', mockUser, 'token');
+
+    expect(result).toBe(true);
+  });
+
+  it('should return false when user is neither entitled nor internal', async () => {
+    (fetch as jest.MockedFunction<typeof fetch>).mockResolvedValue({
+      ok: true,
+      json: async () => ({ isEntitled: false, isInternal: false }),
+    } as Response);
+
+    const result = await checkARHAuth('https://access.stage.redhat.com', mockUser, 'token');
+
+    expect(result).toBe(false);
+  });
+
+  it('should return false when network request fails', async () => {
+    const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    (fetch as jest.MockedFunction<typeof fetch>).mockResolvedValue({
+      ok: false,
+    } as Response);
+
+    const result = await checkARHAuth('https://access.stage.redhat.com', mockUser, 'token');
+
+    expect(result).toBe(false);
+    consoleSpy.mockRestore();
+  });
+
+  it('should return false when response has invalid format', async () => {
+    (fetch as jest.MockedFunction<typeof fetch>).mockResolvedValue({
+      ok: true,
+      json: async () => ({ invalidField: true }),
+    } as Response);
+
+    const result = await checkARHAuth('https://access.stage.redhat.com', mockUser, 'token');
+
+    expect(result).toBe(false);
+  });
+
+  it('should return false and log error when fetch throws', async () => {
+    const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    (fetch as jest.MockedFunction<typeof fetch>).mockRejectedValue(new Error('Network error'));
+
+    const result = await checkARHAuth('https://access.stage.redhat.com', mockUser, 'token');
+
+    expect(result).toBe(false);
+    expect(consoleSpy).toHaveBeenCalledWith('Error checking ARH authentication:', expect.any(Error));
+
+    consoleSpy.mockRestore();
+  });
+});

--- a/src/Components/ARHClient/checkARHAuth.ts
+++ b/src/Components/ARHClient/checkARHAuth.ts
@@ -1,0 +1,54 @@
+import { ChromeUser } from '@redhat-cloud-services/types';
+
+const CHECK_URL = '/hydra/rest/contacts/sso/current';
+
+type CheckARHAuthResponse = {
+  isEntitled: boolean;
+  isInternal: boolean;
+};
+
+function isCheckARHAuthResponse(data: unknown): data is CheckARHAuthResponse {
+  return (
+    typeof data === 'object' &&
+    data !== null &&
+    'isEntitled' in data &&
+    typeof data.isEntitled === 'boolean' &&
+    'isInternal' in data &&
+    typeof data.isInternal === 'boolean'
+  );
+}
+
+async function checkARHAuth(baseUrl: string, user: ChromeUser, token: string): Promise<boolean> {
+  const url = new URL(baseUrl);
+  url.pathname = CHECK_URL;
+  const params = new URLSearchParams();
+  params.set('userId', user.identity.internal?.account_id || '');
+  params.set('assumeEntitledIfSubscriptionServiceUnavailable', 'true');
+  params.set('redhat_client', 'cloud-services');
+  params.set('account_number', user.identity.account_number || '');
+  url.search = params.toString();
+  try {
+    const response = await fetch(url.toString(), {
+      method: 'GET',
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/json',
+      },
+    });
+
+    if (!response.ok) {
+      throw new Error('Network response was not ok');
+    }
+
+    const data = await response.json();
+    if (isCheckARHAuthResponse(data)) {
+      return data.isEntitled || data.isInternal;
+    }
+    return false;
+  } catch (error) {
+    console.error('Error checking ARH authentication:', error);
+    return false;
+  }
+}
+
+export default checkARHAuth;

--- a/src/SharedComponents/AstroVirtualAssistant/__tests__/AstroVirtualAssistant.test.tsx
+++ b/src/SharedComponents/AstroVirtualAssistant/__tests__/AstroVirtualAssistant.test.tsx
@@ -1,0 +1,228 @@
+/* eslint-disable @typescript-eslint/no-empty-function */
+import * as React from 'react';
+import { render, waitFor } from '@testing-library/react';
+import { Provider } from 'react-redux';
+import { createStore } from 'redux';
+import AstroVirtualAssistant from '../AstroVirtualAssistant';
+import { ChromeUser } from '@redhat-cloud-services/types';
+
+// Mock fetch to test the actual checkARHAuth function
+global.fetch = jest.fn();
+
+// Mock the useChrome hook - provides auth context
+const mockChrome = {
+  getEnvironment: jest.fn(),
+  isBeta: jest.fn(() => false),
+  auth: {
+    getUser: jest.fn(),
+    token: 'mock-token',
+  },
+};
+
+jest.mock('@redhat-cloud-services/frontend-components/useChrome', () => ({
+  __esModule: true,
+  default: jest.fn(() => mockChrome),
+}));
+
+// Mock feature flag hook - requires Unleash context
+jest.mock('@unleash/proxy-client-react', () => ({
+  useFlag: jest.fn(() => true),
+}));
+
+// Mock navigation hook - requires router context
+jest.mock('@redhat-cloud-services/frontend-components-utilities/useInsightsNavigate', () => ({
+  useInsightsNavigate: () => jest.fn(),
+}));
+
+// Mock react-markdown - ESM module causing parsing issues
+jest.mock('react-markdown', () => ({
+  __esModule: true,
+  default: ({ children }: { children: string }) => <div>{children}</div>,
+}));
+
+// Mock components that have complex dependencies
+jest.mock('../../../Components/ARHClient/ARHChatbot', () => ({
+  __esModule: true,
+  default: () => <div data-testid="arh-chatbot">ARH Chatbot</div>,
+}));
+
+jest.mock('../../../Components/ARHClient/ARHBadge', () => ({
+  __esModule: true,
+  default: () => <div data-testid="arh-badge">ARH Badge</div>,
+}));
+
+// AstroVirtualAssistantLegacy is exported from the same file, so we don't need to mock it
+
+// Create a minimal Redux store for testing
+const mockStore = createStore(() => ({}));
+
+const mockUser: ChromeUser = {
+  entitlements: {},
+  identity: {
+    org_id: 'org-123',
+    account_number: '123456',
+    internal: {
+      org_id: 'org-123',
+      account_id: 'account-123',
+    },
+    type: 'User',
+    user: {
+      is_internal: true,
+      is_org_admin: false,
+      locale: 'en-US',
+      username: 'testuser',
+      email: 'test@example.com',
+      first_name: 'Test',
+      last_name: 'User',
+      is_active: true,
+    },
+  },
+};
+
+describe('AstroVirtualAssistant ARH Show Condition', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockChrome.getEnvironment.mockReturnValue('stage');
+    mockChrome.auth.getUser.mockResolvedValue(mockUser);
+  });
+
+  it('should show ARH when user is entitled', async () => {
+    (fetch as jest.MockedFunction<typeof fetch>).mockResolvedValue({
+      ok: true,
+      json: async () => ({ isEntitled: true, isInternal: false }),
+    } as Response);
+
+    const { queryByTestId } = render(
+      <Provider store={mockStore}>
+        <AstroVirtualAssistant showAssistant={true} />
+      </Provider>
+    );
+
+    await waitFor(() => {
+      expect(fetch).toHaveBeenCalledWith(
+        'https://access.stage.redhat.com/hydra/rest/contacts/sso/current?userId=account-123&assumeEntitledIfSubscriptionServiceUnavailable=true&redhat_client=cloud-services&account_number=123456',
+        expect.objectContaining({
+          method: 'GET',
+          headers: expect.objectContaining({
+            Authorization: 'Bearer mock-token',
+          }),
+        })
+      );
+    });
+
+    await waitFor(() => {
+      expect(queryByTestId('arh-badge')).toBeInTheDocument();
+    });
+  });
+
+  it('should show ARH when user is internal', async () => {
+    (fetch as jest.MockedFunction<typeof fetch>).mockResolvedValue({
+      ok: true,
+      json: async () => ({ isEntitled: false, isInternal: true }),
+    } as Response);
+
+    const { queryByTestId } = render(
+      <Provider store={mockStore}>
+        <AstroVirtualAssistant showAssistant={true} />
+      </Provider>
+    );
+
+    await waitFor(() => {
+      expect(queryByTestId('arh-badge')).toBeInTheDocument();
+    });
+  });
+
+  it('should not show ARH when user is neither entitled nor internal', async () => {
+    const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    (fetch as jest.MockedFunction<typeof fetch>).mockResolvedValue({
+      ok: true,
+      json: async () => ({ isEntitled: false, isInternal: false }),
+    } as Response);
+
+    const { queryByTestId } = render(
+      <Provider store={mockStore}>
+        <AstroVirtualAssistant showAssistant={true} />
+      </Provider>
+    );
+
+    await waitFor(() => {
+      expect(queryByTestId('arh-badge')).not.toBeInTheDocument();
+    });
+
+    consoleSpy.mockRestore();
+  });
+
+  it('should use production URL for prod environment', async () => {
+    mockChrome.getEnvironment.mockReturnValue('prod');
+    (fetch as jest.MockedFunction<typeof fetch>).mockResolvedValue({
+      ok: true,
+      json: async () => ({ isEntitled: true, isInternal: false }),
+    } as Response);
+
+    render(
+      <Provider store={mockStore}>
+        <AstroVirtualAssistant showAssistant={true} />
+      </Provider>
+    );
+
+    await waitFor(() => {
+      expect(fetch).toHaveBeenCalledWith(expect.stringContaining('https://access.redhat.com/hydra/rest/contacts/sso/current'), expect.any(Object));
+    });
+  });
+
+  it('should use stage URL for stage environment', async () => {
+    mockChrome.getEnvironment.mockReturnValue('stage');
+    (fetch as jest.MockedFunction<typeof fetch>).mockResolvedValue({
+      ok: true,
+      json: async () => ({ isEntitled: true, isInternal: false }),
+    } as Response);
+
+    render(
+      <Provider store={mockStore}>
+        <AstroVirtualAssistant showAssistant={true} />
+      </Provider>
+    );
+
+    await waitFor(() => {
+      expect(fetch).toHaveBeenCalledWith(
+        expect.stringContaining('https://access.stage.redhat.com/hydra/rest/contacts/sso/current'),
+        expect.any(Object)
+      );
+    });
+  });
+
+  it('should not show ARH when user is not available', async () => {
+    mockChrome.auth.getUser.mockResolvedValue(undefined);
+
+    const { queryByTestId } = render(
+      <Provider store={mockStore}>
+        <AstroVirtualAssistant showAssistant={true} />
+      </Provider>
+    );
+
+    await waitFor(() => {
+      expect(fetch).not.toHaveBeenCalled();
+      expect(queryByTestId('arh-badge')).not.toBeInTheDocument();
+    });
+  });
+
+  it('should not show ARH when API request fails', async () => {
+    const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    (fetch as jest.MockedFunction<typeof fetch>).mockResolvedValue({
+      ok: false,
+    } as Response);
+
+    const { queryByTestId } = render(
+      <Provider store={mockStore}>
+        <AstroVirtualAssistant showAssistant={true} />
+      </Provider>
+    );
+
+    await waitFor(() => {
+      expect(fetch).toHaveBeenCalled();
+      expect(queryByTestId('arh-badge')).not.toBeInTheDocument();
+    });
+
+    consoleSpy.mockRestore();
+  });
+});

--- a/src/__mocks__/fileMock.js
+++ b/src/__mocks__/fileMock.js
@@ -1,0 +1,1 @@
+module.exports = 'test-file-stub';

--- a/src/types/jest-dom.d.ts
+++ b/src/types/jest-dom.d.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -25,7 +25,9 @@
   "exclude": [
     "./src/entry.ts",
     "./*.js",
-    "./*.d.ts",
-    "./src/**/__tests__/**"
+    "./*.d.ts"
+  ],
+  "types": [
+    "@testing-library/jest-dom"
   ]
 }


### PR DESCRIPTION
part of: https://issues.redhat.com/browse/RHCLOUD-41455

Run a preflight check for ARH to verify if user has permissions to interact with the chatbot.