### PR TITLE
Allow classnames to be passed as props for VA

### DIFF
--- a/src/SharedComponents/AstroVirtualAssistant/AstroVirtualAssistant.tsx
+++ b/src/SharedComponents/AstroVirtualAssistant/AstroVirtualAssistant.tsx
@@ -103,7 +103,7 @@ export const AstroVirtualAssistantLegacy: FunctionComponent<AstroVirtualAssistan
   );
 };
 
-const AstroVirtualAssistant = (props: { showAssistant: boolean }) => {
+const AstroVirtualAssistant = (props: { showAssistant: boolean; className?: string }) => {
   const useArh = useFlag('platform.arh.enabled');
   const [isOpen, setOpen] = useState<boolean>(false);
   const chrome = useChrome();
@@ -170,7 +170,7 @@ const AstroVirtualAssistant = (props: { showAssistant: boolean }) => {
     );
   }, [showArh, props.showAssistant, isOpen]);
   return createPortal(
-    <div className="virtualAssistant">
+    <div className={`virtualAssistant ${props.className || ''}`}>
       <Stack className="astro-wrapper-stack">{nodes}</Stack>
     </div>,
     document.body


### PR DESCRIPTION
Trying a different approach for https://github.com/RedHatInsights/insights-chrome/pull/3180/ which requires us to allow VA to accept classnames as props