### PR TITLE
Do not show legacy chatbot on assisted installer pages

### DIFF
--- a/src/SharedComponents/AstroVirtualAssistant/AstroVirtualAssistant.tsx
+++ b/src/SharedComponents/AstroVirtualAssistant/AstroVirtualAssistant.tsx
@@ -4,6 +4,7 @@ import { createPortal } from 'react-dom';
 import useChrome from '@redhat-cloud-services/frontend-components/useChrome';
 import { Stack, StackItem } from '@patternfly/react-core';
 import { useFlag } from '@unleash/proxy-client-react';
+import { useMatch } from 'react-router-dom';
 
 import { Status, useAstro } from '../../Components/AstroChat/useAstro';
 import './astro-virtual-assistant.scss';
@@ -104,6 +105,7 @@ export const AstroVirtualAssistantLegacy: FunctionComponent<AstroVirtualAssistan
 
 const AstroVirtualAssistant = (props: { showAssistant: boolean; className?: string }) => {
   const { stateManager, model, chatbotProps, isOpen, setOpen } = useStateManager();
+  const isAssistedInstallerRoute = useMatch('/openshift/assisted-installer/*');
   const nodes = useMemo(() => {
     if (model && stateManager && props.showAssistant) {
       return (
@@ -118,6 +120,10 @@ const AstroVirtualAssistant = (props: { showAssistant: boolean; className?: stri
           </StackItem>
         </AIStateProvider>
       );
+    }
+
+    if (isAssistedInstallerRoute) {
+      return null;
     }
 
     return (

--- a/src/SharedComponents/AstroVirtualAssistant/__tests__/AstroVirtualAssistant.test.tsx
+++ b/src/SharedComponents/AstroVirtualAssistant/__tests__/AstroVirtualAssistant.test.tsx
@@ -5,6 +5,7 @@ import { Provider } from 'react-redux';
 import { createStore } from 'redux';
 import AstroVirtualAssistant from '../AstroVirtualAssistant';
 import { ChromeUser } from '@redhat-cloud-services/types';
+import { MemoryRouter } from 'react-router-dom';
 
 // Mock fetch to test the actual checkARHAuth function
 global.fetch = jest.fn();
@@ -105,9 +106,11 @@ describe('AstroVirtualAssistant ARH Show Condition', () => {
     } as Response);
 
     const { queryByTestId } = render(
-      <Provider store={mockStore}>
-        <AstroVirtualAssistant showAssistant={true} />
-      </Provider>
+      <MemoryRouter>
+        <Provider store={mockStore}>
+          <AstroVirtualAssistant showAssistant={true} />
+        </Provider>
+      </MemoryRouter>
     );
 
     await waitFor(() => {
@@ -134,9 +137,11 @@ describe('AstroVirtualAssistant ARH Show Condition', () => {
     } as Response);
 
     const { queryByTestId } = render(
-      <Provider store={mockStore}>
-        <AstroVirtualAssistant showAssistant={true} />
-      </Provider>
+      <MemoryRouter>
+        <Provider store={mockStore}>
+          <AstroVirtualAssistant showAssistant={true} />
+        </Provider>
+      </MemoryRouter>
     );
 
     await waitFor(() => {
@@ -152,9 +157,11 @@ describe('AstroVirtualAssistant ARH Show Condition', () => {
     } as Response);
 
     const { queryByTestId } = render(
-      <Provider store={mockStore}>
-        <AstroVirtualAssistant showAssistant={true} />
-      </Provider>
+      <MemoryRouter>
+        <Provider store={mockStore}>
+          <AstroVirtualAssistant showAssistant={true} />
+        </Provider>
+      </MemoryRouter>
     );
 
     await waitFor(() => {
@@ -173,9 +180,11 @@ describe('AstroVirtualAssistant ARH Show Condition', () => {
     } as Response);
 
     render(
-      <Provider store={mockStore}>
-        <AstroVirtualAssistant showAssistant={true} />
-      </Provider>
+      <MemoryRouter>
+        <Provider store={mockStore}>
+          <AstroVirtualAssistant showAssistant={true} />
+        </Provider>
+      </MemoryRouter>
     );
 
     await waitFor(() => {
@@ -191,9 +200,11 @@ describe('AstroVirtualAssistant ARH Show Condition', () => {
     } as Response);
 
     render(
-      <Provider store={mockStore}>
-        <AstroVirtualAssistant showAssistant={true} />
-      </Provider>
+      <MemoryRouter>
+        <Provider store={mockStore}>
+          <AstroVirtualAssistant showAssistant={true} />
+        </Provider>
+      </MemoryRouter>
     );
 
     await waitFor(() => {
@@ -208,9 +219,11 @@ describe('AstroVirtualAssistant ARH Show Condition', () => {
     mockChrome.auth.getUser.mockResolvedValue(undefined);
 
     render(
-      <Provider store={mockStore}>
-        <AstroVirtualAssistant showAssistant={true} />
-      </Provider>
+      <MemoryRouter>
+        <Provider store={mockStore}>
+          <AstroVirtualAssistant showAssistant={true} />
+        </Provider>
+      </MemoryRouter>
     );
 
     await waitFor(() => {
@@ -228,9 +241,11 @@ describe('AstroVirtualAssistant ARH Show Condition', () => {
     } as Response);
 
     const { queryByTestId } = render(
-      <Provider store={mockStore}>
-        <AstroVirtualAssistant showAssistant={true} />
-      </Provider>
+      <MemoryRouter>
+        <Provider store={mockStore}>
+          <AstroVirtualAssistant showAssistant={true} />
+        </Provider>
+      </MemoryRouter>
     );
 
     await waitFor(() => {
@@ -274,9 +289,11 @@ describe('AstroVirtualAssistant ARH Show Condition', () => {
     } as Response);
 
     render(
-      <Provider store={mockStore}>
-        <AstroVirtualAssistant showAssistant={true} />
-      </Provider>
+      <MemoryRouter>
+        <Provider store={mockStore}>
+          <AstroVirtualAssistant showAssistant={true} />
+        </Provider>
+      </MemoryRouter>
     );
 
     await waitFor(() => {
@@ -292,14 +309,32 @@ describe('AstroVirtualAssistant ARH Show Condition', () => {
     mockUseFlag.mockReturnValue(false); // Disable ARH feature flag
 
     const { queryByTestId } = render(
-      <Provider store={mockStore}>
-        <AstroVirtualAssistant showAssistant={true} />
-      </Provider>
+      <MemoryRouter>
+        <Provider store={mockStore}>
+          <AstroVirtualAssistant showAssistant={true} />
+        </Provider>
+      </MemoryRouter>
     );
 
     await waitFor(() => {
       // No badge should be visible when feature flag is disabled
       expect(queryByTestId('arh-badge')).not.toBeInTheDocument();
+    });
+  });
+
+  it('should not render legacy if path is /openshift/assisted-installer', async () => {
+    mockUseFlag.mockReturnValue(false); // Disable ARH feature flag
+
+    render(
+      <MemoryRouter initialEntries={['/openshift/assisted-installer/foo']}>
+        <Provider store={mockStore}>
+          <AstroVirtualAssistant showAssistant={true} />
+        </Provider>
+      </MemoryRouter>
+    );
+
+    await waitFor(() => {
+      expect(screen.queryByAltText('Launch virtual assistant')).not.toBeInTheDocument();
     });
   });
 });


### PR DESCRIPTION
The chrome PR https://github.com/RedHatInsights/insights-chrome/pull/3193 enables chatbot on assisted-installer pages. However we want only the new one, not the legacy