### PR TITLE
Show conversation warning only for ARH bot

### DIFF
--- a/src/Components/UniversalChatbot/UniversalChatbot.tsx
+++ b/src/Components/UniversalChatbot/UniversalChatbot.tsx
@@ -11,6 +11,7 @@ import UniversalHeader from './UniversalHeader';
 import UniversalFooter from './UniversalFooter';
 import UniversalMessages from './UniversalMessages';
 import UniversalAssistantSelection from './UniversalAssistantSelection';
+import { Models } from '../../aiClients/types';
 
 import '@patternfly/chatbot/dist/css/main.css';
 
@@ -140,7 +141,7 @@ function UniversalChatbot({ setOpen, currentModel, setCurrentModel, managers }: 
                 ? undefined
                 : () => {
                     // TODO: figure out nice way to handle custom conversation creation flow
-                    setShowNewConversationWarning(true);
+                    currentModel === Models.ASK_RED_HAT && setShowNewConversationWarning(true);
                     manager?.handleNewChat?.(setConversationsDrawerOpened);
                   }
             }


### PR DESCRIPTION
This is a quick-fix for an issue where a new conversation modal appears even if it should not

steps to reproduce:
1. open a chatbot which has conversation history, other than ARH (ie Assisted one)
2. click create new conversation
3. switch to ARH
4. new conversation modal appears (but it should not, we just switched the chatbots)
5. user has to click confirm or cancel
6. if user clicks confirm, all previous chatbot conversations  (the Assisted ones!) are marked as locked - again incorrect

For a proper fix, we would ideally not want to have a specific model comparison (`currentModel === Models.ASK_RED_HAT`). This quick-fix should be enough until we figure out a proper custom conversation creation flow (as  existing TODO says already)