### PR TITLE
Fixing VA scrollup issue - VA is creating new message array refs on each render (RHCLOUD-42882)

### DIFF
--- a/src/aiClients/vaClient.ts
+++ b/src/aiClients/vaClient.ts
@@ -28,6 +28,7 @@ class VAClient implements IAIClient<VAAdditionalAttributes> {
   private _isInitialized = false;
   private _isInitializing = false;
   private initialApiResponse: PostTalkResponseAPI | null = null;
+  private cachedWelcomeConfig: WelcomeConfig | null = null;
   async createNewConversation(): Promise<IConversation> {
     // VA does not manage conversations
     return {
@@ -90,6 +91,11 @@ class VAClient implements IAIClient<VAAdditionalAttributes> {
   }
 
   getWelcomeConfig(): WelcomeConfig {
+    // Return cached config if available to maintain stable references
+    if (this.cachedWelcomeConfig) {
+      return this.cachedWelcomeConfig;
+    }
+
     if (!this._isInitialized || !this.initialApiResponse) {
       // Return empty config to let useVaManager handle the default content
       return {
@@ -124,6 +130,9 @@ class VAClient implements IAIClient<VAAdditionalAttributes> {
       content,
       buttons,
     };
+
+    // Cache the result to maintain stable references across calls
+    this.cachedWelcomeConfig = result;
 
     return result;
   }


### PR DESCRIPTION
The `getWelcomeConfig()` method was creating a new buttons array every time it was called, even though the content never changed.

The Fix - Cache the welcome config
  - Added a `cachedWelcomeConfig` property to maintain stable object references
  - Now `getWelcomeConfig()` returns the same cached object instead of creating new ones

![va-fix-scrollup-issue](https://github.com/user-attachments/assets/c11cb266-8628-45f5-9449-d7a002b03517)
