### PR TITLE
Add column flex-direction in VAEmbed component

### DIFF
--- a/src/SharedComponents/VAEmbed/VAEmbed.scss
+++ b/src/SharedComponents/VAEmbed/VAEmbed.scss
@@ -1,3 +1,9 @@
+.va-embed {
+  .pf-chatbot--embedded .pf-chatbot--layout--welcome .pf-chatbot__prompt-suggestions {
+    flex-direction: column;
+  }
+}
+
 .va-embed-error {
   padding: 1rem;
   text-align: center;


### PR DESCRIPTION
For [RHCLOUD-47504](https://redhat.atlassian.net/browse/RHCLOUD-47504). Previously, in the help panel, there would be horizontal overflow in the VAEmbed component that allowed horizontal scrolling. This change matches it closer to the VA opened with the speech bubble and _should_ prevent horizontal scrolling.

Before:
<img width="451" height="727" alt="image" src="https://github.com/user-attachments/assets/f7df15d3-6913-4119-8ed4-0df48dd7f3f9" />

After:
<img width="451" height="727" alt="image" src="https://github.com/user-attachments/assets/84f8d5e2-552a-4db8-9307-5dd2c0729791" />


[RHCLOUD-47504]: https://redhat.atlassian.net/browse/RHCLOUD-47504?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ