### PR TITLE
Force column on VAEmbed component

### DIFF
--- a/src/SharedComponents/VAEmbed/VAEmbed.scss
+++ b/src/SharedComponents/VAEmbed/VAEmbed.scss
@@ -1,6 +1,6 @@
 .va-embed {
-  .pf-chatbot--embedded .pf-chatbot--layout--welcome .pf-chatbot__prompt-suggestions {
-    flex-direction: column;
+  .pf-chatbot--embedded .pf-chatbot__prompt-suggestions {
+    flex-direction: column !important;
   }
 }
 

--- a/src/SharedComponents/VAEmbed/VAEmbed.scss
+++ b/src/SharedComponents/VAEmbed/VAEmbed.scss
@@ -1,6 +1,8 @@
 .va-embed {
-  .pf-chatbot--embedded .pf-chatbot__prompt-suggestions {
-    flex-direction: column !important;
+  @media screen and (min-width: 64rem) {
+    .pf-chatbot--embedded .pf-chatbot--layout--welcome .pf-chatbot__prompt-suggestions {
+      flex-direction: column;
+    }
   }
 }
 


### PR DESCRIPTION
The `scss` in https://github.com/RedHatInsights/astro-virtual-assistant-frontend/pull/376 wasn't enough for stage to force column direction for the help panel chatbot. There's something with the way Patternfly forces views when resizing. Hopefully this fixes the problem. Previewing with `window.insights.chrome.drawerActions.toggleDrawerContent({scope: 'virtualAssistant', module: './VAEmbed'})` unfortunately doesn't show the problem as PF styles aren't applied 