### PR TITLE
feat(agents): add new hcc-ai-assistant integration option

### DIFF
--- a/cypress/components/useHccAiManager.cy.tsx
+++ b/cypress/components/useHccAiManager.cy.tsx
@@ -3,34 +3,7 @@ import { ScalprumProvider } from '@scalprum/react-core';
 import { FlagProvider } from '@unleash/proxy-client-react';
 import useHccAiManager from '../../src/aiClients/useHccAiManager';
 import { Models } from '../../src/aiClients/types';
-
-const mockChromeApi = {
-  auth: {
-    getToken: () => Promise.resolve('mock-token'),
-    getUser: () =>
-      Promise.resolve({
-        identity: {
-          user: {
-            username: 'testuser',
-            email: 'test@test.com',
-            first_name: 'Test',
-            last_name: 'User',
-            is_internal: false,
-            is_active: true,
-            is_org_admin: true,
-            locale: 'en-US',
-          },
-          account_number: '123456',
-          internal: { account_id: '123456' },
-          org_id: 'test-org',
-          type: 'User',
-        },
-        entitlements: {},
-      }),
-  },
-  getEnvironment: () => 'stage',
-  isBeta: () => false,
-};
+import { mockChromeApi } from '../mocks/chromeApi';
 
 const UseHccAiManagerComponent = () => {
   const { manager, loading } = useHccAiManager();

--- a/cypress/components/useHccAiManager.cy.tsx
+++ b/cypress/components/useHccAiManager.cy.tsx
@@ -1,0 +1,133 @@
+import React from 'react';
+import { ScalprumProvider } from '@scalprum/react-core';
+import { FlagProvider } from '@unleash/proxy-client-react';
+import useHccAiManager from '../../src/aiClients/useHccAiManager';
+import { Models } from '../../src/aiClients/types';
+
+const mockChromeApi = {
+  auth: {
+    getToken: () => Promise.resolve('mock-token'),
+    getUser: () =>
+      Promise.resolve({
+        identity: {
+          user: {
+            username: 'testuser',
+            email: 'test@test.com',
+            first_name: 'Test',
+            last_name: 'User',
+            is_internal: false,
+            is_active: true,
+            is_org_admin: true,
+            locale: 'en-US',
+          },
+          account_number: '123456',
+          internal: { account_id: '123456' },
+          org_id: 'test-org',
+          type: 'User',
+        },
+        entitlements: {},
+      }),
+  },
+  getEnvironment: () => 'stage',
+  isBeta: () => false,
+};
+
+const UseHccAiManagerComponent = () => {
+  const { manager, loading } = useHccAiManager();
+
+  return (
+    <div>
+      <div data-testid="loading">{String(loading)}</div>
+      <div data-testid="has-manager">{String(!!manager)}</div>
+      <div data-testid="model">{manager?.model}</div>
+      <div data-testid="model-name">{manager?.modelName}</div>
+      <div data-testid="selection-title">{manager?.selectionTitle}</div>
+      <div data-testid="history-management">{String(manager?.historyManagement)}</div>
+      <div data-testid="stream-messages">{String(manager?.streamMessages)}</div>
+      <div data-testid="has-message-entry">{String(!!manager?.MessageEntryComponent)}</div>
+      <div data-testid="has-state-manager">{String(!!manager?.stateManager)}</div>
+      <div data-testid="welcome-buttons">
+        {JSON.stringify(manager?.welcome?.buttons?.map((b) => b.title) ?? [])}
+      </div>
+    </div>
+  );
+};
+
+const mountWithFlags = (toggles: Array<{ name: string; enabled: boolean }>) => {
+  cy.intercept('GET', '**/api/frontend**', {
+    statusCode: 200,
+    body: { toggles },
+  }).as('unleashAPI');
+
+  cy.intercept('POST', '**/api/frontend/client/metrics', {
+    statusCode: 200,
+    body: {},
+  }).as('unleashMetrics');
+
+  cy.mount(
+    <ScalprumProvider config={{}} api={{ chrome: mockChromeApi }}>
+      <FlagProvider
+        config={{
+          url: 'http://localhost:4242/api/frontend',
+          clientKey: 'test-key',
+          appName: 'test-app',
+        }}
+      >
+        <UseHccAiManagerComponent />
+      </FlagProvider>
+    </ScalprumProvider>,
+  );
+};
+
+describe('useHccAiManager', () => {
+  describe('when feature flag is off', () => {
+    beforeEach(() => {
+      mountWithFlags([]);
+    });
+
+    it('should return null manager', () => {
+      cy.get('[data-testid="has-manager"]').should('contain', 'false');
+    });
+
+    it('should not be loading', () => {
+      cy.get('[data-testid="loading"]').should('contain', 'false');
+    });
+  });
+
+  describe('when feature flag is on', () => {
+    beforeEach(() => {
+      mountWithFlags([
+        { name: 'platform.chatbot.hcc-ai-assistant.enabled', enabled: true },
+      ]);
+    });
+
+    it('should return HCC AI model', () => {
+      cy.get('[data-testid="model"]').should('contain', Models.HCC_AI);
+      cy.get('[data-testid="model-name"]').should('contain', 'HCC AI Assistant');
+      cy.get('[data-testid="selection-title"]').should('contain', 'HCC AI Assistant');
+    });
+
+    it('should have a state manager', () => {
+      cy.get('[data-testid="has-state-manager"]').should('contain', 'true');
+    });
+
+    it('should not use a custom MessageEntryComponent', () => {
+      cy.get('[data-testid="has-message-entry"]').should('contain', 'false');
+    });
+
+    it('should provide static welcome buttons', () => {
+      cy.get('[data-testid="welcome-buttons"]').should(
+        'contain',
+        '["What can you help me with?","List the principals in my organization"]',
+      );
+    });
+
+    it('should not stream messages', () => {
+      cy.get('[data-testid="stream-messages"]').should('contain', 'false');
+    });
+
+    it('should enable history management', () => {
+      cy.get('[data-testid="history-management"]').should('contain', 'true');
+    });
+  });
+});

--- a/cypress/components/useVaManager.cy.tsx
+++ b/cypress/components/useVaManager.cy.tsx
@@ -3,34 +3,7 @@ import { ScalprumProvider } from '@scalprum/react-core';
 import { FlagProvider } from '@unleash/proxy-client-react';
 import useVaManager from '../../src/aiClients/useVaManager';
 import { Models } from '../../src/aiClients/types';
-
-const mockChromeApi = {
-  auth: {
-    getToken: () => Promise.resolve('mock-token'),
-    getUser: () =>
-      Promise.resolve({
-        identity: {
-          user: {
-            username: 'testuser',
-            email: 'test@test.com',
-            first_name: 'Test',
-            last_name: 'User',
-            is_internal: false,
-            is_active: true,
-            is_org_admin: true,
-            locale: 'en-US',
-          },
-          account_number: '123456',
-          internal: { account_id: '123456' },
-          org_id: 'test-org',
-          type: 'User',
-        },
-        entitlements: {},
-      }),
-  },
-  getEnvironment: () => 'stage',
-  isBeta: () => false,
-};
+import { mockChromeApi } from '../mocks/chromeApi';
 
 const UseVaManagerComponent = () => {
   const { manager, loading } = useVaManager();

--- a/cypress/components/useVaManager.cy.tsx
+++ b/cypress/components/useVaManager.cy.tsx
@@ -1,0 +1,107 @@
+import React from 'react';
+import { ScalprumProvider } from '@scalprum/react-core';
+import { FlagProvider } from '@unleash/proxy-client-react';
+import useVaManager from '../../src/aiClients/useVaManager';
+import { Models } from '../../src/aiClients/types';
+
+const mockChromeApi = {
+  auth: {
+    getToken: () => Promise.resolve('mock-token'),
+    getUser: () =>
+      Promise.resolve({
+        identity: {
+          user: {
+            username: 'testuser',
+            email: 'test@test.com',
+            first_name: 'Test',
+            last_name: 'User',
+            is_internal: false,
+            is_active: true,
+            is_org_admin: true,
+            locale: 'en-US',
+          },
+          account_number: '123456',
+          internal: { account_id: '123456' },
+          org_id: 'test-org',
+          type: 'User',
+        },
+        entitlements: {},
+      }),
+  },
+  getEnvironment: () => 'stage',
+  isBeta: () => false,
+};
+
+const UseVaManagerComponent = () => {
+  const { manager, loading } = useVaManager();
+
+  return (
+    <div>
+      <div data-testid="loading">{String(loading)}</div>
+      <div data-testid="model">{manager?.model}</div>
+      <div data-testid="model-name">{manager?.modelName}</div>
+      <div data-testid="selection-title">{manager?.selectionTitle}</div>
+      <div data-testid="history-management">{String(manager?.historyManagement)}</div>
+      <div data-testid="stream-messages">{String(manager?.streamMessages)}</div>
+      <div data-testid="has-message-entry">{String(!!manager?.MessageEntryComponent)}</div>
+      <div data-testid="has-state-manager">{String(!!manager?.stateManager)}</div>
+      <div data-testid="welcome-buttons">
+        {JSON.stringify(manager?.welcome?.buttons?.map((b) => b.title) ?? [])}
+      </div>
+    </div>
+  );
+};
+
+const mountComponent = () => {
+  cy.intercept('GET', '**/api/frontend**', {
+    statusCode: 200,
+    body: { toggles: [] },
+  }).as('unleashAPI');
+
+  cy.intercept('POST', '**/api/frontend/client/metrics', {
+    statusCode: 200,
+    body: {},
+  }).as('unleashMetrics');
+
+  cy.mount(
+    <ScalprumProvider config={{}} api={{ chrome: mockChromeApi }}>
+      <FlagProvider
+        config={{
+          url: 'http://localhost:4242/api/frontend',
+          clientKey: 'test-key',
+          appName: 'test-app',
+        }}
+      >
+        <UseVaManagerComponent />
+      </FlagProvider>
+    </ScalprumProvider>,
+  );
+};
+
+describe('useVaManager', () => {
+  beforeEach(() => {
+    mountComponent();
+  });
+
+  it('should return VA model configuration', () => {
+    cy.get('[data-testid="model"]').should('contain', Models.VA);
+    cy.get('[data-testid="model-name"]').should('contain', 'Hybrid Cloud Console - Virtual Assistant');
+    cy.get('[data-testid="selection-title"]').should('contain', 'Hybrid Cloud Console');
+  });
+
+  it('should use VAMessageEntry component', () => {
+    cy.get('[data-testid="has-message-entry"]').should('contain', 'true');
+  });
+
+  it('should have a state manager', () => {
+    cy.get('[data-testid="has-state-manager"]').should('contain', 'true');
+  });
+
+  it('should not stream messages', () => {
+    cy.get('[data-testid="stream-messages"]').should('contain', 'false');
+  });
+
+  it('should not manage history', () => {
+    cy.get('[data-testid="history-management"]').should('contain', 'false');
+  });
+});

--- a/cypress/mocks/chromeApi.ts
+++ b/cypress/mocks/chromeApi.ts
@@ -1,0 +1,27 @@
+export const mockChromeApi = {
+  auth: {
+    getToken: () => Promise.resolve('mock-token'),
+    getUser: () =>
+      Promise.resolve({
+        identity: {
+          user: {
+            username: 'testuser',
+            email: 'test@test.com',
+            first_name: 'Test',
+            last_name: 'User',
+            is_internal: false,
+            is_active: true,
+            is_org_admin: true,
+            locale: 'en-US',
+          },
+          account_number: '123456',
+          internal: { account_id: '123456' },
+          org_id: '123456',
+          type: 'User',
+        },
+        entitlements: {},
+      }),
+  },
+  getEnvironment: () => 'stage',
+  isBeta: () => false,
+};

--- a/fec.config.js
+++ b/fec.config.js
@@ -36,6 +36,7 @@ module.exports = {
       './useArhChatbot': path.resolve(__dirname, './src/aiClients/useArhClient.ts'),
       './useRhelChatbot': path.resolve(__dirname, './src/aiClients/useRhelLightSpeedManager.ts'),
       './useVaChatbot': path.resolve(__dirname, './src/aiClients/useVaManager.ts'),
+      './useHccAiChatbot': path.resolve(__dirname, './src/aiClients/useHccAiManager.ts'),
       './state/globalState': path.resolve(__dirname, './src/utils/VirtualAssistantStateSingleton.ts'),
       ...extraExposes,
     },

--- a/src/aiClients/__tests__/useHccAiManager.test.ts
+++ b/src/aiClients/__tests__/useHccAiManager.test.ts
@@ -123,5 +123,71 @@ describe('useHccAiManager', () => {
 
       expect(result.current.loading).toBe(false);
     });
+
+    describe('fetchFunction behavior', () => {
+      let fetchFunction: (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>;
+      let mockFetch: jest.Mock;
+      const originalFetch = global.fetch;
+
+      beforeEach(() => {
+        const { LightspeedClient } = jest.requireMock('@redhat-cloud-services/lightspeed-client');
+        mockFetch = jest.fn().mockResolvedValue({ ok: true });
+        global.fetch = mockFetch;
+
+        renderHook(() => useHccAiManager());
+
+        fetchFunction = LightspeedClient.mock.calls[0][0].fetchFunction;
+      });
+
+      afterEach(() => {
+        global.fetch = originalFetch;
+      });
+
+      it('should add Authorization header', async () => {
+        await fetchFunction('https://example.com/v1/info', { headers: {} });
+
+        expect(mockFetch).toHaveBeenCalledWith(
+          'https://example.com/v1/info',
+          expect.objectContaining({
+            headers: expect.objectContaining({
+              Authorization: 'Bearer mock-token',
+            }),
+          })
+        );
+      });
+
+      it('should inject model and provider for query requests', async () => {
+        const body = JSON.stringify({ query: 'hello' });
+        await fetchFunction('https://example.com/v1/query', { body, headers: {} });
+
+        const calledBody = JSON.parse(mockFetch.mock.calls[0][1].body);
+        expect(calledBody.model).toBe('publishers/google/models/gemini-2.5-flash');
+        expect(calledBody.provider).toBe('google-vertex');
+        expect(calledBody.query).toBe('hello');
+      });
+
+      it('should inject model and provider for streaming_query requests', async () => {
+        const body = JSON.stringify({ query: 'hello' });
+        await fetchFunction('https://example.com/v1/streaming_query', { body, headers: {} });
+
+        const calledBody = JSON.parse(mockFetch.mock.calls[0][1].body);
+        expect(calledBody.model).toBe('publishers/google/models/gemini-2.5-flash');
+        expect(calledBody.provider).toBe('google-vertex');
+      });
+
+      it('should not modify body for non-query requests', async () => {
+        const body = JSON.stringify({ some: 'data' });
+        await fetchFunction('https://example.com/v1/conversations', { body, headers: {} });
+
+        expect(mockFetch.mock.calls[0][1].body).toBe(body);
+      });
+
+      it('should leave body unchanged if JSON parsing fails', async () => {
+        const body = 'not-valid-json';
+        await fetchFunction('https://example.com/v1/query', { body, headers: {} });
+
+        expect(mockFetch.mock.calls[0][1].body).toBe(body);
+      });
+    });
   });
 });

--- a/src/aiClients/__tests__/useHccAiManager.test.ts
+++ b/src/aiClients/__tests__/useHccAiManager.test.ts
@@ -1,0 +1,127 @@
+import { renderHook } from '@testing-library/react';
+import useHccAiManager from '../useHccAiManager';
+import { Models } from '../types';
+
+// Mock LightspeedClient
+jest.mock('@redhat-cloud-services/lightspeed-client', () => {
+  const mockClient = {
+    init: jest.fn().mockResolvedValue({ conversations: [] }),
+    sendMessage: jest.fn(),
+    createNewConversation: jest.fn(),
+    getConversationHistory: jest.fn().mockResolvedValue([]),
+    healthCheck: jest.fn(),
+  };
+  return {
+    LightspeedClient: jest.fn(() => mockClient),
+  };
+});
+
+// Mock AI client state
+const mockStateManager = {
+  isInitialized: jest.fn(() => false),
+  isInitializing: jest.fn(() => false),
+  init: jest.fn(),
+  getClient: jest.fn(),
+  subscribe: jest.fn(() => jest.fn()),
+};
+
+jest.mock('@redhat-cloud-services/ai-client-state', () => ({
+  createClientStateManager: jest.fn(() => mockStateManager),
+}));
+
+// Mock useChrome
+jest.mock('@redhat-cloud-services/frontend-components/useChrome', () => ({
+  __esModule: true,
+  default: () => ({
+    auth: {
+      getToken: jest.fn().mockResolvedValue('mock-token'),
+    },
+  }),
+}));
+
+// Track useFlag return value
+let mockUseFlagReturn = false;
+jest.mock('@unleash/proxy-client-react', () => ({
+  useFlag: jest.fn(() => mockUseFlagReturn),
+}));
+
+describe('useHccAiManager', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseFlagReturn = false;
+  });
+
+  describe('when feature flag is off', () => {
+    it('should return null manager', () => {
+      const { result } = renderHook(() => useHccAiManager());
+
+      expect(result.current.manager).toBeNull();
+      expect(result.current.loading).toBe(false);
+    });
+  });
+
+  describe('when feature flag is on', () => {
+    beforeEach(() => {
+      mockUseFlagReturn = true;
+    });
+
+    it('should create LightspeedClient with correct config', () => {
+      const { LightspeedClient } = jest.requireMock('@redhat-cloud-services/lightspeed-client');
+
+      renderHook(() => useHccAiManager());
+
+      expect(LightspeedClient).toHaveBeenCalledWith(
+        expect.objectContaining({
+          baseUrl: expect.stringContaining('/api/ai-assistant'),
+          fetchFunction: expect.any(Function),
+        })
+      );
+    });
+
+    it('should return HCC_AI model', () => {
+      const { result } = renderHook(() => useHccAiManager());
+
+      expect(result.current.manager?.model).toBe(Models.HCC_AI);
+    });
+
+    it('should enable history management', () => {
+      const { result } = renderHook(() => useHccAiManager());
+
+      expect(result.current.manager?.historyManagement).toBe(true);
+    });
+
+    it('should not stream messages', () => {
+      const { result } = renderHook(() => useHccAiManager());
+
+      expect(result.current.manager?.streamMessages).toBe(false);
+    });
+
+    it('should provide static welcome buttons', () => {
+      const { result } = renderHook(() => useHccAiManager());
+
+      expect(result.current.manager?.welcome?.buttons).toEqual([
+        { title: 'What can you help me with?', value: 'What can you help me with?' },
+        { title: 'List the principals in my organization', value: 'List the principals in my organization' },
+      ]);
+    });
+
+    it('should not have a custom MessageEntryComponent', () => {
+      const { result } = renderHook(() => useHccAiManager());
+
+      expect(result.current.manager?.MessageEntryComponent).toBeUndefined();
+    });
+
+    it('should set correct model name and selection info', () => {
+      const { result } = renderHook(() => useHccAiManager());
+
+      expect(result.current.manager?.modelName).toBe('HCC AI Assistant');
+      expect(result.current.manager?.selectionTitle).toBe('HCC AI Assistant');
+    });
+
+    it('should not be loading', () => {
+      const { result } = renderHook(() => useHccAiManager());
+
+      expect(result.current.loading).toBe(false);
+    });
+  });
+});

--- a/src/aiClients/types.ts
+++ b/src/aiClients/types.ts
@@ -6,6 +6,7 @@ export enum Models {
   RHEL_LIGHTSPEED = 'RHEL Lightspeed',
   VA = 'Virtual Assistant',
   OAI = 'OpenShift assisted Installer',
+  HCC_AI = 'HCC AI Assistant',
 }
 
 export interface WelcomeButton {

--- a/src/aiClients/useHccAiManager.ts
+++ b/src/aiClients/useHccAiManager.ts
@@ -19,10 +19,14 @@ export default function useHccAiManager(): UseManagerHook {
         // Tracking: https://redhat-internal.slack.com/archives/C07MC7G9T8A/p1778709207779339
         let body = options?.body;
         if (typeof input === 'string' && /\/v1\/(streaming_)?query$/.test(input) && typeof body === 'string') {
-          const parsed = JSON.parse(body);
-          parsed.model = 'publishers/google/models/gemini-2.5-flash';
-          parsed.provider = 'google-vertex';
-          body = JSON.stringify(parsed);
+          try {
+            const parsed = JSON.parse(body);
+            parsed.model = 'publishers/google/models/gemini-2.5-flash';
+            parsed.provider = 'google-vertex';
+            body = JSON.stringify(parsed);
+          } catch {
+            // leave body unchanged if parsing fails
+          }
         }
         return fetch(input, {
           ...options,

--- a/src/aiClients/useHccAiManager.ts
+++ b/src/aiClients/useHccAiManager.ts
@@ -1,0 +1,71 @@
+import { useMemo } from 'react';
+import { LightspeedClient } from '@redhat-cloud-services/lightspeed-client';
+import { createClientStateManager } from '@redhat-cloud-services/ai-client-state';
+import useChrome from '@redhat-cloud-services/frontend-components/useChrome';
+import { useFlag } from '@unleash/proxy-client-react';
+import { Models, StateManagerConfiguration, UseManagerHook } from './types';
+
+export default function useHccAiManager(): UseManagerHook {
+  const isEnabled = useFlag('platform.chatbot.hcc-ai-assistant.enabled');
+  const chrome = useChrome();
+
+  const manager = useMemo(() => {
+    const client = new LightspeedClient({
+      baseUrl: `${window.location.origin}/api/ai-assistant`,
+      fetchFunction: async (input, options) => {
+        const token = await chrome.auth.getToken();
+        // TODO: Remove the `let body` reassignment, the `if` block below, and the `body` override in the fetch call
+        // once llama-stack fixes model name normalization for allowed_models validation.
+        // Tracking: https://redhat-internal.slack.com/archives/C07MC7G9T8A/p1778709207779339
+        let body = options?.body;
+        if (typeof input === 'string' && /\/v1\/(streaming_)?query$/.test(input) && typeof body === 'string') {
+          const parsed = JSON.parse(body);
+          parsed.model = 'publishers/google/models/gemini-2.5-flash';
+          parsed.provider = 'google-vertex';
+          body = JSON.stringify(parsed);
+        }
+        return fetch(input, {
+          ...options,
+          body,
+          headers: {
+            ...options?.headers,
+            Authorization: `Bearer ${token}`,
+          },
+        });
+      },
+    });
+    const stateManager = createClientStateManager(client);
+
+    const configuration: StateManagerConfiguration<LightspeedClient> = {
+      model: Models.HCC_AI,
+      historyManagement: true,
+      streamMessages: false,
+      modelName: 'HCC AI Assistant',
+      selectionTitle: 'HCC AI Assistant',
+      selectionDescription: 'Get help with the Hybrid Cloud Console, manage your organization, configure settings, and more.',
+      stateManager,
+      docsUrl:
+        'https://docs.redhat.com/en/documentation/red_hat_hybrid_cloud_console/1-latest/html/getting_started_with_the_red_hat_hybrid_cloud_console/hcc-help-options_getting-started#virtual-assistant_getting-started',
+      welcome: {
+        buttons: [
+          {
+            title: 'What can you help me with?',
+            value: 'What can you help me with?',
+          },
+          {
+            title: 'List the principals in my organization',
+            value: 'List the principals in my organization',
+          },
+        ],
+      },
+    };
+
+    return configuration;
+  }, [chrome]);
+
+  if (!isEnabled) {
+    return { manager: null, loading: false };
+  }
+
+  return { manager, loading: false };
+}

--- a/src/aiClients/useStateManager.ts
+++ b/src/aiClients/useStateManager.ts
@@ -22,6 +22,10 @@ function useAsyncManagers(): StateManagerConfiguration<IAIClient>[] | undefined 
       module: './useRhelChatbot',
     });
     addHook({
+      scope: 'virtualAssistant',
+      module: './useHccAiChatbot',
+    });
+    addHook({
       scope: 'assistedInstallerApp',
       module: './useAsyncChatbot',
     });


### PR DESCRIPTION
https://redhat.atlassian.net/browse/RHCLOUD-47025

Summary
  
  - Adds a new HCC AI Assistant as a standalone chatbot backend, gated behind the `platform.chatbot.hcc-ai-assistant.enabled` feature flag
  - Follows the established pluggable manager pattern (dedicated hook, model enum entry, module federation export) — same as ARH, RHEL Lightspeed, and OAI integrations
  - Includes a temporary workaround in the `fetchFunction` to inject model and provider into query request bodies, working around a llama-stack model name normalization bug (https://redhat-internal.slack.com/archives/C07MC7G9T8A/p1778709207779339) that causes 500 errors

  Known issues

  - Backend 500 errors: The HCC AI Assistant backend (hcc-ai-assistant) is currently returning 500 errors on all query requests due to a CancelledError originating from the Google Vertex AI provider in llama-stack (different than 500 errors above). This is a backend/infrastructure issue (not frontend) and needs to be investigated separately. The frontend integration is complete and will work once the backend is stable. **EDIT** I've opened a potential fix here: https://github.com/RedHatInsights/hcc-ai-assistant/pull/64

  Changes

  - `src/aiClients/useHccAiManager.ts `(new) — Manager hook using LightspeedClient pointed at /api/ai-assistant, with auth token injection and the model name workaround
  - `src/aiClients/types.ts` — Added HCC_AI to the Models enum
  - `src/aiClients/useStateManager.ts` — Registered the new hook via useRemoteHookManager
  - `fec.config.js` — Added ./useHccAiChatbot module federation expose
  - `src/aiClients/__tests__/useHccAiManager.test.ts` (new) — 9 Jest unit tests (flag on/off, client config, model, history, welcome buttons)
  - `cypress/components/useHccAiManager.cy.tsx` (new) — 8 Cypress component tests

  Test plan

  - Verified npm run lint passes
  - Verified npm test passes (all Jest tests including new useHccAiManager.test.ts)
  - Verified npm run cypress:run:cp passes (all Cypress tests including new useHccAiManager.cy.tsx)
  - Verified npm run build succeeds
  - Verified With feature flag off: HCC AI Assistant does not appear in the chatbot dropdown
  - Verified With feature flag on: HCC AI Assistant appears as a selectable option with correct welcome buttons and title

Screenshots
<img width="591" height="964" alt="image" src="https://github.com/user-attachments/assets/7ed1e22f-970c-435c-9e4c-1521790b142f" />
<img width="513" height="799" alt="image" src="https://github.com/user-attachments/assets/0a7523d3-da6a-49b4-a49c-2b030491d31e" />
