### PR TITLE
Force column for VAEmbed

### DIFF
--- a/src/SharedComponents/VAEmbed/VAEmbed.scss
+++ b/src/SharedComponents/VAEmbed/VAEmbed.scss
@@ -1,8 +1,6 @@
 .va-embed {
-  @media screen and (min-width: 64rem) {
-    .pf-chatbot--embedded .pf-chatbot--layout--welcome .pf-chatbot__prompt-suggestions {
-      flex-direction: column;
-    }
+  .pf-chatbot__prompt-suggestions {
+    flex-direction: column !important;
   }
 }
 


### PR DESCRIPTION
The previous change wasn't enough unfortunately. Adding `!important` to force column mode which should be the only mode possible for the help panel.