### PR TITLE
Revert singleton header changes and add css to hide

### DIFF
--- a/src/Components/UniversalChatbot/UniversalChatbot.tsx
+++ b/src/Components/UniversalChatbot/UniversalChatbot.tsx
@@ -12,12 +12,10 @@ import UniversalFooter from './UniversalFooter';
 import UniversalMessages from './UniversalMessages';
 import UniversalAssistantSelection from './UniversalAssistantSelection';
 import { Models } from '../../aiClients/types';
-import { useHideHeader } from '../../utils/VirtualAssistantStateSingleton';
 
 import '@patternfly/chatbot/dist/css/main.css';
 
 function UniversalChatbot({ setOpen, currentModel, setCurrentModel, managers, displayMode: propDisplayMode }: ChatbotProps) {
-  const [hideHeader] = useHideHeader();
   const [displayMode, setDisplayMode] = useState<ChatbotDisplayMode>(propDisplayMode || ChatbotDisplayMode.default);
   const effectiveDisplayMode = propDisplayMode || displayMode;
   const [isBannerOpen, setIsBannerOpen] = useState(true);
@@ -73,17 +71,15 @@ function UniversalChatbot({ setOpen, currentModel, setCurrentModel, managers, di
 
   const drawerContent = (
     <>
-      {!hideHeader && (
-        <UniversalHeader
-          historyManagement={!!manager?.historyManagement}
-          conversationsDrawerOpened={conversationsDrawerOpened}
-          scrollToBottomRef={scrollToBottomRef}
-          setOpen={setOpen}
-          setDisplayMode={propDisplayMode ? undefined : setDisplayMode}
-          displayMode={effectiveDisplayMode}
-          isCompact
-        />
-      )}
+      <UniversalHeader
+        historyManagement={!!manager?.historyManagement}
+        conversationsDrawerOpened={conversationsDrawerOpened}
+        scrollToBottomRef={scrollToBottomRef}
+        setOpen={setOpen}
+        setDisplayMode={propDisplayMode ? undefined : setDisplayMode}
+        displayMode={effectiveDisplayMode}
+        isCompact
+      />
       <UniversalAssistantSelection containerRef={rootElementRef} />
       <UniversalMessages
         isBannerOpen={isBannerOpen}

--- a/src/SharedComponents/VAEmbed/VAEmbed.scss
+++ b/src/SharedComponents/VAEmbed/VAEmbed.scss
@@ -1,4 +1,8 @@
-.va-embed {
+.virtualAssistant .va-embed {
+  .pf-chatbot__header {
+    display: none;
+  }
+
   // Fallback for any other prompt-suggestions instances
   .pf-chatbot__prompt-suggestions {
     flex-direction: column;

--- a/src/utils/VirtualAssistantStateSingleton.ts
+++ b/src/utils/VirtualAssistantStateSingleton.ts
@@ -19,12 +19,10 @@ export type VirtualAssistantState = {
   isOpen: boolean;
   message?: string;
   currentModel?: Models;
-  hideHeader: boolean;
 };
 
 const initialState: VirtualAssistantState = {
   isOpen: false,
-  hideHeader: false,
 };
 
 export class VirtualAssistantStateSingleton {
@@ -50,10 +48,6 @@ export class VirtualAssistantStateSingleton {
 
   public static setCurrentModel(value: Models | undefined) {
     VirtualAssistantStateSingleton.getInstance().currentModel = value;
-  }
-
-  public static setHideHeader(value: boolean) {
-    VirtualAssistantStateSingleton.getInstance().hideHeader = value;
   }
 
   public static getState() {
@@ -97,15 +91,6 @@ export class VirtualAssistantStateSingleton {
     VirtualAssistantStateSingleton._state.currentModel = value;
     this.notify();
   }
-
-  get hideHeader() {
-    return VirtualAssistantStateSingleton._state.hideHeader;
-  }
-
-  set hideHeader(value: boolean) {
-    VirtualAssistantStateSingleton._state.hideHeader = value;
-    this.notify();
-  }
 }
 
 export const useCurrentModel = (): [Models | undefined, Dispatch<SetStateAction<Models | undefined>>] => {
@@ -142,24 +127,6 @@ export const useMessage = (): [string | undefined, Dispatch<SetStateAction<strin
   };
 
   return [message, setMessage];
-};
-
-export const useHideHeader = (): [boolean, Dispatch<SetStateAction<boolean>>] => {
-  const [hideHeader, setHideHeaderState] = useState(VirtualAssistantStateSingleton.getInstance().hideHeader);
-
-  useEffect(() => {
-    const unsubscribe = VirtualAssistantStateSingleton.getInstance().subscribe(() => {
-      setHideHeaderState(VirtualAssistantStateSingleton.getInstance().hideHeader);
-    });
-    return unsubscribe;
-  }, []);
-
-  const setHideHeader = (value: SetStateAction<boolean>) => {
-    const newValue = typeof value === 'function' ? value(VirtualAssistantStateSingleton.getInstance().hideHeader) : value;
-    VirtualAssistantStateSingleton.getInstance().hideHeader = newValue;
-  };
-
-  return [hideHeader, setHideHeader];
 };
 
 export const useIsOpen = (): [boolean, Dispatch<SetStateAction<boolean>>] => {
@@ -221,9 +188,6 @@ export const useVirtualAssistant = (): [VirtualAssistantState, (updates: Partial
     }
     if ('currentModel' in newValue) {
       instance.currentModel = newValue.currentModel;
-    }
-    if ('hideHeader' in newValue && newValue.hideHeader !== undefined) {
-      instance.hideHeader = newValue.hideHeader;
     }
   };
 


### PR DESCRIPTION
For [RHCLOUD-47952](https://redhat.atlassian.net/browse/RHCLOUD-47952). Reverts the singleton changes to hide the header and just uses css to accomplish this. Since this component is only being used in the help panel, hiding the header for this component specifically should suffice. Verifiable locally by running `window.insights.chrome.drawerActions.toggleDrawerContent({scope: 'virtualAssistant', module: './VAEmbed'})` in the console.

[RHCLOUD-47952]: https://redhat.atlassian.net/browse/RHCLOUD-47952?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ