### PR TITLE
fix(hcc-ai-assistant-option): send generate_topic_summary as false te…

### DIFF
--- a/src/aiClients/__tests__/useHccAiManager.test.ts
+++ b/src/aiClients/__tests__/useHccAiManager.test.ts
@@ -156,23 +156,25 @@ describe('useHccAiManager', () => {
         );
       });
 
-      it('should inject model and provider for query requests', async () => {
+      it('should inject model, provider, and disable topic summary for query requests', async () => {
         const body = JSON.stringify({ query: 'hello' });
         await fetchFunction('https://example.com/v1/query', { body, headers: {} });
 
         const calledBody = JSON.parse(mockFetch.mock.calls[0][1].body);
         expect(calledBody.model).toBe('publishers/google/models/gemini-2.5-flash');
         expect(calledBody.provider).toBe('google-vertex');
+        expect(calledBody.generate_topic_summary).toBe(false);
         expect(calledBody.query).toBe('hello');
       });
 
-      it('should inject model and provider for streaming_query requests', async () => {
+      it('should inject model, provider, and disable topic summary for streaming_query requests', async () => {
         const body = JSON.stringify({ query: 'hello' });
         await fetchFunction('https://example.com/v1/streaming_query', { body, headers: {} });
 
         const calledBody = JSON.parse(mockFetch.mock.calls[0][1].body);
         expect(calledBody.model).toBe('publishers/google/models/gemini-2.5-flash');
         expect(calledBody.provider).toBe('google-vertex');
+        expect(calledBody.generate_topic_summary).toBe(false);
       });
 
       it('should not modify body for non-query requests', async () => {

--- a/src/aiClients/useHccAiManager.ts
+++ b/src/aiClients/useHccAiManager.ts
@@ -23,6 +23,9 @@ export default function useHccAiManager(): UseManagerHook {
             const parsed = JSON.parse(body);
             parsed.model = 'publishers/google/models/gemini-2.5-flash';
             parsed.provider = 'google-vertex';
+            // Workaround: topic summary generation times out due to unknown bug in lightspeed-stack,
+            // even though it should be performed in the background.
+            parsed.generate_topic_summary = false;
             body = JSON.stringify(parsed);
           } catch {
             // leave body unchanged if parsing fails


### PR DESCRIPTION
### Description

  Disables topic summary generation (`generate_topic_summary: false`) in query requests to the HCC AI Assistant. Topic summary generation currently times out due to an unknown bug in lightspeed-stack, even though it should be performed in the background.
  
  This is a temporary workaround to unblock demos.

  No JIRA ticket — temporary workaround.

  ---
  
  ### Screenshots

  _N/A — no visible UI changes. This modifies the request payload sent to the backend._

  ---
  
  ### Anything reviewers should know?

  This is a temporary workaround, similar to the existing model/provider override in the same `fetchFunction`. Once the lightspeed-stack bug is resolved, `generate_topic_summary` should be removed so topic summaries work again.

  ---
  
  ### Checklist
  - [x] Accessibility: color contrast, keyboard nav, screen reader tested (or N/A)
  - [x] All PR checks pass locally (build, lint, test)
  - [x] No unrelated changes included
  - [ ] _(Optional) QE: OUIA changed, test impact, no coverage_
  - [ ] _(Optional) UX: end-user UX modified, designs need sign-off_

  ### AI disclosure
  Assisted by: Claude Code (Opus 4.6)